### PR TITLE
Add methods to enable remote modification of the database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# HEAD
+
+-   Add methods to `RemoteInsDb` to add/modify/delete objects in a remote database [#2](https://github.com/ziotom78/libinsdb/pull/2)
+
+# Version 0.1.0
+
+-   First public release

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,4 +1,16 @@
+.. _installation-label:
+
 Installation
 ============
 
-Libinsdb is indexed on the Python Package Index. More information will be added here later.
+Libinsdb is indexed on the Python Package Index. To install it, just run the command
+
+.. code-block::
+
+    pip3 install libinsdb
+
+If you use `Poetry <https://python-poetry.org/>`_, run
+
+.. code-block::
+
+    poetry add libinsdb

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -34,7 +34,7 @@ available at https://insdbdemo.fisica.unimi.it:
 
     from libinsdb import RemoteInsDb
 
-    # The instrument database is kept locally, so it was
+    # The instrument database is kept remotely, so it was
     # dumped from a running InstrumentDB instance
     insdb = RemoteInsDb(
         server_address="https://insdbdemo.fisica.unimi.it",
@@ -53,3 +53,11 @@ available at https://insdbdemo.fisica.unimi.it:
     # In the case of the Planck bandpasses, we know that they
     # are saved using UTF-8 encoding.
     print(contents.decode("utf-8"))
+
+
+
+Local vs remote databases
+-------------------------
+
+As shown in the two examples above, Libinsdb lets you to interface a local copy or a remote database running the full server. There is one important difference between the two cases: you can alter the content of the database only if you are accessing a remote copy, while a local copy is always read-only. The reason for this is that changes in the database are handled by the remote InstrumentDB server, which implements full validation checks for every change.
+

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -26,7 +26,7 @@ Once you have activate your virtual environment, you can install Libinsdb using 
 
     pip3 install libinsdb
 
-Refer to :ref:`Installation` for further details.
+Refer to :ref:`installation-label` for further details.
 
 Connecting to the database
 --------------------------
@@ -68,3 +68,48 @@ Remember that the file is always opened in binary mode; thus, if you know it is 
 
     decoded_contents = contents.decode("utf-8")
 
+
+Modifying the content of the database
+-------------------------------------
+
+If you are accessing a local copy of the database, only read-only operations are enabled. However, if you instantiate an object of type :class:`.RemoteInsDb`, then additional methods are available with respect to :class:`.LocalInsDb`:
+
+- :meth:`.RemoteInsDb.patch` lets you to change any object in the database, be it a specification document, a data file, a quantity, etc.
+- :meth:`.RemoteInsDb.delete` lets you to remove any object in the database.
+- :meth:`.RemoteInsDb.post` lets you to add a new object in the database.
+
+The most used operation is of course to add new objects to the database, which is the reason why :class:`.RemoteInsDb` provides a few additional high-level methods that wrap :meth:`.RemoteInsDb.post`:
+
+1. :meth:`.RemoteInsDb.create_format_spec` creates a new format specification;
+2. :meth:`.RemoteInsDb.create_entity` creates a new entity;
+3. :meth:`.RemoteInsDb.create_quantity` creates a new quantity;
+4. :meth:`.RemoteInsDb.create_data_file` creates a new data file;
+5. :meth:`.RemoteInsDb.create_release` creates a new release.
+
+Each of these high-level functions returns the URL of the new object and enables an easier syntax to specify where the new objects should be created::
+
+    # With .post(), you must know the URL of the parent entity and be
+    # sure to include the relevant keys in the dictionary
+    response = db.post(
+        url="http://localhost/api/quantities/",
+        data={
+            "name": "my_quantity",
+            "format_spec": format_spec_url,
+            "parent_entity": parent_entity_url,  # ←
+        },
+    )
+    quantity_url = response["url"]
+
+    # With .create_quantity, you just specify the path
+    # where to store the quantity
+    quantity_url = db.create_quantity(
+        name="my quantity",
+        parent_path="root/sub_entity1/sub_entity2",
+        format_spec_url=format_spec_url,
+    )
+
+
+A real-world case
+-----------------
+
+The website https://insdbdemo.fisica.unimi.it shows a demo of InstrumentDB hosting a reduced instrument model of the ESA Planck spacecraft. The code used to fill the database is available at https://github.com/ziotom78/planck_insdb_demo and can be used as a reference to use Libinsdb in a real-world scenario.

--- a/libinsdb/local.py
+++ b/libinsdb/local.py
@@ -164,7 +164,11 @@ class InstrumentDbFormatError(Exception):
 
 
 class LocalInsDb(InstrumentDatabase):
-    """A class that interfaces with a flat-file representation of a database."""
+    """A class that interfaces with a flat-file representation of a database.
+
+    This class assumes that the storage is read-only: no change in the files
+    is ever done!
+    """
 
     def __init__(self, storage_path: Union[str, Path]):
         super().__init__()

--- a/libinsdb/remote.py
+++ b/libinsdb/remote.py
@@ -431,7 +431,7 @@ class RemoteInsDb(InstrumentDatabase):
         quantity: str,
         parent_path: str,
         data_file_path: Path | None = None,
-        data_file_name: str = None,
+        data_file_name: str | None = None,
         plot_file_path: Path | None = None,
         plot_file: BufferedReader | None = None,
         plot_file_name: str | None = None,

--- a/libinsdb/remote.py
+++ b/libinsdb/remote.py
@@ -1,5 +1,9 @@
 # -*- encoding: utf-8 -*-
+from __future__ import annotations
 
+import json
+from io import BufferedReader
+from pathlib import Path
 from tempfile import TemporaryFile
 from typing import Any, Union, IO
 from urllib.parse import urljoin
@@ -18,13 +22,8 @@ class InstrumentDbConnectionError(Exception):
 
     The fields of this class contain details about the failed requests:
 
-    - ``response``: the ``requests.Response` object associated with the failed
+    - ``response``: the ``requests.Response`` object associated with the failed
        request.
-
-    - ``url``: the URL of the failed request
-
-    - ``http_code``: the HTTP response status code; see
-       https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
 
     - ``message``: a human-readable error message detailing what went wrong
     """
@@ -32,8 +31,15 @@ class InstrumentDbConnectionError(Exception):
     def __init__(self, response: requests.Response, message: str):
         self.response = response
         self.url = response.url
+        # See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
         self.http_code = response.status_code
         self.message = message
+
+    def __str__(self):
+        return (
+            f"HTTP error {self.http_code} from {self.url}: "
+            f"{self.message=}, {self.response=}"
+        )
 
 
 def extract_last_part_from_url(url: str) -> str:
@@ -51,7 +57,52 @@ def uuid_from_url(url: str) -> UUID:
     return UUID(extract_last_part_from_url(url))
 
 
+def _validate_response_and_return_json(response: requests.Response) -> dict[str, Any]:
+    """Check that the response is ok; otherwise, raise an InstrumentDBError"""
+
+    if not response.ok:
+        raise InstrumentDbConnectionError(
+            message=response.text,
+            response=response,
+        )
+
+    if response.content == b"":
+        return {}
+
+    try:
+        return response.json()
+    except requests.exceptions.JSONDecodeError as err:
+        raise InstrumentDbConnectionError(
+            message=f"{response=} returned {err=} with {response.reason=}",
+            response=response,
+        )
+
+
+def _normalize_relative_path(parent_path: str) -> str:
+    "Remove leading and trailing backslashes from a relative URL path"
+
+    if parent_path.startswith("/"):
+        parent_path.removeprefix("/")
+
+    if parent_path.endswith("/"):
+        parent_path.removesuffix("/")
+
+    return parent_path
+
+
 class RemoteInsDb(InstrumentDatabase):
+    """A class that interfaces with a remote InstrumentDB server.
+
+    This class implements the interface of the abstract class
+    :class:`.InstrumentDatabase`, which means that it is able
+    to access the database much like the class :class:`.LocalInsDb`.
+
+    In addition, this class implements methods that are able to
+    modify the content of the database, either by patching what is
+    already saved in the database, by adding new objects, or by
+    deleting existing ones.
+    """
+
     def __init__(self, server_address: str, username: str, password: str):
         super().__init__()
 
@@ -205,3 +256,316 @@ class RemoteInsDb(InstrumentDatabase):
         f.seek(0)
 
         return f
+
+    def post(
+        self, url: str, data: dict[str, Any], files: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Send a POST request to the server
+
+        This method should be used to create a *new* object in the database,
+        be it a format specification, an entity, a quantity, or a data file.
+
+        If the object requires files to be associated with it (for example,
+        a PDF document), you must pass it through the `files` parameter.
+
+        If there is an error connecting to the server, a `InstrumentDBError`
+        will be raised.
+        """
+
+        response = requests.post(
+            url=url,
+            data=data,
+            files={} if files is None else files,
+            headers=self.auth_header,
+        )
+        return _validate_response_and_return_json(response)
+
+    def get(self, url: str, params: Any = None) -> dict[str, Any]:
+        """Send a GET request to the server
+
+        This method should be used to retrieve information about
+        one or more objects in the database.
+
+        If the object requires files to be associated with it (for example,
+        a PDF document), you must pass it through the `files` parameter.
+
+        If there is an error connecting to the server, a `InstrumentDBError`
+        will be raised.
+        """
+
+        if url != "" and url[-1] != "/":
+            url = url + "/"
+
+        response = requests.get(
+            url=url,
+            headers=self.auth_header,
+            params=params if params is not None else {},
+        )
+        return _validate_response_and_return_json(response)
+
+    def patch(
+        self, url: str, data: dict[str, Any], files: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Send a PATCH request to the server
+
+        This method should be used to modify an existing object in the database.
+
+        If the object requires files to be associated with it (for example,
+        a PDF document), you must pass it through the `files` parameter.
+
+        If there is an error connecting to the server, a `InstrumentDBError`
+        will be raised.
+        """
+
+        response = requests.patch(
+            url=url,
+            data=data,
+            files={} if files is None else files,
+            headers=self.auth_header,
+        )
+        return _validate_response_and_return_json(response)
+
+    def delete(self, url: str) -> dict[str, Any]:
+        """Send a DELETE request to the server
+
+        This method should be used to remove objects (entities, quantities,
+        data files, format specifications) from the database.
+
+        If there is an error connecting to the server, a `InstrumentDBError`
+        will be raised.
+        """
+
+        response = requests.delete(
+            url=url,
+            headers=self.auth_header,
+        )
+        return _validate_response_and_return_json(response)
+
+    def create_format_spec(
+        self,
+        document_ref: str,
+        document_title: str,
+        document_file: IO,
+        document_file_name: str,
+        document_mime_type: str,
+        file_mime_type: str,
+    ) -> str:
+        """Add a new format specification to the database
+
+        Each of the parameters to this method match the parameters needed by
+        the API to create a format specification.
+
+        Return the URL of the new format specification.
+        """
+
+        response = self.post(
+            url=f"{self.server_address}/api/format_specs/",
+            data={
+                "document_ref": document_ref,
+                "title": document_title,
+                "doc_file_name": document_file_name,
+                "doc_mime_type": document_mime_type,
+                "file_mime_type": file_mime_type,
+            },
+            files={
+                "doc_file": document_file,
+            },
+        )
+        return response["url"]
+
+    def create_entity(self, name: str, parent_path: str | None = None) -> str:
+        """Add a new entity to the database
+
+        This creates an entity named `name`, which is a child of the entity
+        whose path is `parent_path` (a full path, not just the name of the
+        parent entity!). If the latter is ``None``, the entity is placed
+        at the topmost position in the tree (root).
+
+        Return the URL of the new entity.
+        """
+        data = {"name": name}
+
+        if parent_path is not None:
+            parent_path = _normalize_relative_path(parent_path)
+            response = self.get(
+                url=f"{self.server_address}/tree/{parent_path}",
+            )
+            data["parent"] = response["url"]
+
+        response = self.post(
+            url=f"{self.server_address}/api/entities/",
+            data=data,
+        )
+        return response["url"]
+
+    def create_quantity(self, name: str, parent_path: str, format_spec_url: str) -> str:
+        """Add a new quantity to the database
+
+        This creates a quantity named `name`, which is placed within the entity
+        whose path is `parent_path` (a full path, not just the name of the
+        parent entity!). The parameter `format_spec_url` must be the URL of
+        a format specification, which must already exist.
+
+        Return the URL of the new quantity.
+        """
+        parent_path = _normalize_relative_path(parent_path)
+        response = self.get(
+            url=f"{self.server_address}/tree/{parent_path}",
+        )
+
+        parent_entity = response["url"]
+        data = {
+            "name": name,
+            "format_spec": format_spec_url,
+            "parent_entity": parent_entity,
+        }
+
+        response = self.post(
+            url=f"{self.server_address}/api/quantities/",
+            data=data,
+        )
+        return response["url"]
+
+    def create_data_file(
+        self,
+        quantity: str,
+        parent_path: str,
+        data_file_path: Path | None = None,
+        data_file_name: str = None,
+        plot_file_path: Path | None = None,
+        plot_file: BufferedReader | None = None,
+        plot_file_name: str | None = None,
+        plot_mime_type: str | None = None,
+        upload_date: str | None = None,
+        spec_version: str = "1.0",
+        metadata: Any = None,
+        comment: str = "",
+    ) -> str:
+        """Add a new data file to the database.
+
+        This creates a data file for `quantity` (the name of the quantity
+        holding this file, not its URL!) within the entity whose path is `parent_path`.
+
+        All the other parameters are the same accepted by the RESTFul API exported
+        by InstrumentDB to create a data file.
+
+        Return the URL of the new data file.
+        """
+        assert not (
+            (plot_file is not None) and (plot_file_path is not None)
+        ), "you cannot specify both 'plot_file' and 'plot_file_path'"
+
+        parent_path = _normalize_relative_path(parent_path)
+        quantity_dict = self.get(
+            url=f"{self.server_address}/tree/{parent_path}/{quantity}"
+        )
+        quantity_url = quantity_dict["url"]
+
+        data = {
+            "quantity": quantity_url,
+            "spec_version": spec_version,
+            "comment": comment,
+            "name": data_file_name if not None else "file",
+        }
+
+        if upload_date is not None:
+            data["upload_date"] = upload_date
+
+        if plot_file_name is not None:
+            data["plot_file_name"] = plot_file_name
+
+        if plot_mime_type is not None:
+            data["plot_mime_type"] = plot_mime_type
+
+        if metadata is not None:
+            if isinstance(metadata, str):
+                data["metadata"] = metadata
+            else:
+                data["metadata"] = json.dumps(metadata)
+
+        files = {}
+
+        files_to_close = []
+        if data_file_path:
+            data["name"] = data_file_path.name
+            files["file_data"] = data_file_path.open("rb")
+            files_to_close.append(files["file_data"])
+
+        if plot_file:
+            files["plot_file"] = plot_file
+        elif plot_file_path:
+            files["plot_file"] = plot_file_path.open("rb")
+            files_to_close.append(files["plot_file"])
+
+        url = f"{self.server_address}/api/data_files/"
+        response = self.post(
+            url=url,
+            data=data,
+            files=files,
+        )
+
+        for cur_file in files_to_close:
+            # CPython automatically closes files, but this is not
+            # the same with PyPy and Jython
+            cur_file.close()
+
+        return response["url"]
+
+    def get_data_file_from_release(self, release: str, path: str):
+        response = self.get(
+            url=f"{self.server_address}/releases/{release}/{path}/",
+        )
+        return response["url"]
+
+    def create_release(
+        self,
+        release_tag: str,
+        data_file_url_list: list[str] | None = None,
+        release_date: str | None = None,
+        release_document_path: Path | None = None,
+        release_document_mime_type: str | None = None,
+        comment: str = "",
+    ) -> str:
+        """Add a new release to the database.
+
+        This creates a release containing all the data files listed in
+        `data_file_url_list` (list of the URLs of each data file).
+
+        All the other parameters are the same to be passed to the
+        RESTful API provided by InstrumentDB to create a release.
+
+        Return the URL of the new release.
+        """
+        if data_file_url_list is None:
+            data_file_url_list = []
+
+        data = {
+            "tag": release_tag,
+            "comment": comment,
+            "data_files": data_file_url_list,
+        }
+        files = {}
+
+        if release_date:
+            data["rel_date"] = release_date
+
+        if release_document_mime_type:
+            data["release_document_mime_type"] = release_document_mime_type
+
+        files_to_close = []
+        if release_document_path:
+            release_document_file = release_document_path.open("rb")
+            files_to_close.append(release_document_file)
+            files["release_document"] = release_document_file
+
+        response = self.post(
+            url=f"{self.server_address}/api/releases/",
+            data=data,
+            files=files,
+        )
+        release_url = response["url"]
+
+        for cur_file in files_to_close:
+            cur_file.close()
+
+        return release_url


### PR DESCRIPTION
With this PR, `RemoteInsDb` implements more methods to add/modify/delete objects on a remote server running InstrumentDB. The class `LocalInsDb` continues to support only read-only operations, and this is not going to be modified any time soon.
