### PR TITLE
Be more tolerant with paths to data files

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -56,9 +56,10 @@ Once you have a working connection to the database, you can run queries using on
 Let's retrieve information about a data file::
 
     data_file = insdb.query_data_file(
-        "planck2021/LFI/frequency_030_ghz/bandpass"
+        "/releases/planck2021/LFI/frequency_030_ghz/bandpass"
     )
 
+(The path we have used here is the one shown at the bottom of the page https://insdbdemo.fisica.unimi.it/browse/data_files/f155cb37-d12e-4645-952f-014086094613/.)
 The method returns a new instance of the :class:`.DataFile` class. If a real file is associated with the class, you can open it using the :meth:`.DataFile.open_data_file` method::
 
     with data_file.open_data_file(insdb) as my_file:
@@ -72,7 +73,7 @@ Remember that the file is always opened in binary mode; thus, if you know it is 
 Modifying the content of the database
 -------------------------------------
 
-If you are accessing a local copy of the database, only read-only operations are enabled. However, if you instantiate an object of type :class:`.RemoteInsDb`, then additional methods are available with respect to :class:`.LocalInsDb`:
+If you are accessing a local copy of the database, only read-only operations are enabled. However, if you instantiate an object of type :class:`.RemoteInsDb` and your user has the proper access rights, then additional methods are available with respect to :class:`.LocalInsDb`:
 
 - :meth:`.RemoteInsDb.patch` lets you to change any object in the database, be it a specification document, a data file, a quantity, etc.
 - :meth:`.RemoteInsDb.delete` lets you to remove any object in the database.
@@ -150,4 +151,5 @@ These instructions can be combined in a script so that a full tree of entities/q
 A real-world case
 -----------------
 
-The website https://insdbdemo.fisica.unimi.it shows a demo of InstrumentDB hosting a reduced instrument model of the ESA Planck spacecraft. The code used to fill the database is available at https://github.com/ziotom78/planck_insdb_demo and can be used as a reference to use Libinsdb in a real-world scenario.
+The website https://insdbdemo.fisica.unimi.it shows a demo of InstrumentDB hosting a reduced instrument model of the ESA Planck spacecraft.
+The code used to fill the database is available at https://github.com/ziotom78/fill_insdb_with_planck_rimo and can be used as a reference to use Libinsdb in a real-world scenario.

--- a/libinsdb/local.py
+++ b/libinsdb/local.py
@@ -388,7 +388,10 @@ class LocalInsDb(InstrumentDatabase):
                 return self.data_files[uuid]
             except ValueError:
                 # We're dealing with a path
-                relname, entity_path, quantity_name = _parse_data_file_path(identifier)
+                stripped_identifier = identifier.removeprefix("/releases/")
+                    
+                relname, entity_path, quantity_name = _parse_data_file_path(stripped_identifier)
+                print(f"DEBUG: {identifier=}, {stripped_identifier=}, {relname=}")
                 release_uuids = self.releases[relname].data_files
                 entity = self.entities[self.path_to_entity[entity_path]]
 

--- a/libinsdb/remote.py
+++ b/libinsdb/remote.py
@@ -246,9 +246,13 @@ class RemoteInsDb(InstrumentDatabase):
             uuid = UUID(identifier)
             return self._query_data_file_from_uuid(uuid, track=track)
         except ValueError:
+            full_identifier = identifier
+            if not full_identifier.startswith("/releases/"):
+                full_identifier = f"/releases/{identifier}"
+
             # `identifier` is a path into the tree
             response = requests.get(
-                urljoin(self.server_address, f"/releases/{identifier}/"),
+                urljoin(self.server_address, full_identifier),
                 headers=self.auth_header,
             )
             self._validate_response(response)

--- a/tests/test_high_level_interface.py
+++ b/tests/test_high_level_interface.py
@@ -46,9 +46,13 @@ def check_all_objects_in_db(insdb: InstrumentDatabase) -> None:
     data_file2 = insdb.query_data_file(str(uuid))
     check_data_file(data_file=data_file2, uuid=uuid)
 
-    data_file3 = insdb.query("/releases/planck2018/LFI/frequency_044_ghz/24M/bandpass")
+    data_file3 = insdb.query("/releases/planck2018/LFI/frequency_044_ghz/24M/bandpass/")
     assert isinstance(data_file3, DataFile)
     assert data_file3.uuid == UUID("3ffd0d49-f06b-4c6a-9885-fb5b4f6db3ac")
+
+    data_file4 = insdb.query_data_file("/releases/planck2018/LFI/frequency_044_ghz/24M/bandpass/")
+    assert isinstance(data_file4, DataFile)
+    assert data_file4.uuid == UUID("3ffd0d49-f06b-4c6a-9885-fb5b4f6db3ac")
 
 
 def create_local_db() -> InstrumentDatabase:


### PR DESCRIPTION
This PR makes libinsdb able to accept paths to data files that start with `/releases/…`, thus making it able to open the paths that are shown at the bottom of pages like https://insdbdemo.fisica.unimi.it/browse/data_files/f155cb37-d12e-4645-952f-014086094613/.
