### PR TITLE
Fix issues when downloading data files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Fix an authentication problem with data files [#10](https://github.com/ziotom78/libinsdb/pull/10)
+
 # Version 0.7.0
 
 -   Be more tolerant with `/releases/` in data file paths [#8](https://github.com/ziotom78/libinsdb/pull/8)

--- a/libinsdb/remote.py
+++ b/libinsdb/remote.py
@@ -210,7 +210,7 @@ class RemoteInsDb(InstrumentDatabase):
             upload_date=data_file_info["upload_date"],
             metadata=parsed_metadata,
             data_file_local_path=None,
-            data_file_download_url=data_file_info["download_link"],
+            data_file_download_url=data_file_info.get("download_link", None),
             quantity=uuid_from_url(data_file_info["quantity"]),
             spec_version=data_file_info["spec_version"],
             dependencies=set(
@@ -284,7 +284,9 @@ class RemoteInsDb(InstrumentDatabase):
 
         f = TemporaryFile("w+b")
         response = requests.get(
-            str(data_file.data_file_download_url), allow_redirects=True
+            str(data_file.data_file_download_url),
+            allow_redirects=True,
+            headers=self.auth_header,
         )
         f.write(response.content)
         f.seek(0)


### PR DESCRIPTION
This small PR fixes two bugs:

-   Don't crash if a data file has no download link;
-   When downloading a data file, don't forget to send the authentication token.
