### PR TITLE
Only warn for missing data files when you're actually opening them

### DIFF
--- a/libinsdb/local.py
+++ b/libinsdb/local.py
@@ -428,24 +428,6 @@ class LocalInsDb(InstrumentDatabase):
 
         """
 
-        # In principle, we should implement this test for all the files available
-        # (format specifications, release notes, plot files…). However:
-        # 1. If the user asks to load missing files, an exception will be raised correctly
-        # 2. The most likely file a user wants is a data file, so we just provide a helpful
-        #    hint about what's wrong in this case, with the hope that whoever is downloading
-        #    any other file using the RESTful interface is expert enough to figure out what's
-        #    wrong.
-        if not self.are_data_files_available:
-            # Data files were not available when this LocalInsDb object was created
-            # but maybe now they are present. Let's check it again
-            are_available_now = self.storage_path / "data_files"
-            if not are_available_now.exists():
-                raise InstrumentDbFormatError(
-                    "You do not seem to have downloaded data files, only the schema file"
-                )
-            else:
-                self.are_data_files_available = True
-
         if isinstance(identifier, UUID):
             if track:
                 self.add_uuid_to_tracked_list(uuid=identifier)
@@ -517,6 +499,25 @@ class LocalInsDb(InstrumentDatabase):
 
     def open_data_file(self, data_file: DataFile) -> IO:
         assert data_file.data_file_local_path is not None
+
+        # In principle, we should implement this test for all the files available
+        # (format specifications, release notes, plot files…). However:
+        # 1. If the user asks to load missing files, an exception will be raised correctly
+        # 2. The most likely file a user wants is a data file, so we just provide a helpful
+        #    hint about what's wrong in this case, with the hope that whoever is downloading
+        #    any other file using the RESTful interface is expert enough to figure out what's
+        #    wrong.
+        if not self.are_data_files_available:
+            # Data files were not available when this LocalInsDb object was created
+            # but maybe now they are present. Let's check it again
+            are_available_now = self.storage_path / "data_files"
+            if not are_available_now.exists():
+                raise InstrumentDbFormatError(
+                    "You do not seem to have downloaded data files, only the schema file"
+                )
+            else:
+                self.are_data_files_available = True
+
         return data_file.data_file_local_path.open("rb")
 
     def merge(self, other: "LocalInsDb") -> None:

--- a/tests/test_local_database.py
+++ b/tests/test_local_database.py
@@ -144,7 +144,7 @@ def test_missing_data_files():
     # This folder does contain data files…
     assert db.are_data_files_available
 
-    mock_db_path = Path(__file__).parent / "mock_db_json_2"
+    mock_db_path = Path(__file__).parent / "mock_db_json_3" / "really_weird_name.json"
     db = LocalInsDb(storage_path=mock_db_path)
     # … but this folder does not
     assert not db.are_data_files_available
@@ -152,8 +152,11 @@ def test_missing_data_files():
     # Check that the correct assertion is raised
     from libinsdb import InstrumentDbFormatError
 
+    data_file = db.query_data_file(UUID("3ffd0d49-f06b-4c6a-9885-fb5b4f6db3ac"))
     with pytest.raises(InstrumentDbFormatError):
-        db.query_data_file(UUID("3ffd0d49-f06b-4c6a-9885-fb5b4f6db3ac"))
+        with data_file.open_data_file(db):
+            # This instruction should never be executed
+            pass
 
 
 def test_merge():


### PR DESCRIPTION
This should fix bug [#317](https://github.com/litebird/litebird_sim/issues/317) in `litebird_sim`. The code raised an error whenever a “data file object” was accessed through the JSON, but the error should have been caused only when the actual file associated with the data file entry was to be opened.

