### PR TITLE
Drop support for Python 3.8 and add support for Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,7 @@ jobs:
       matrix:
         py:
           - "3.9"
-          - "3.10"
-          - "3.11"
+          - "3.12"
         os:
           - ubuntu-latest
           - macos-latest

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
 [tox]
 env_list =
-    lint, flake8, type, py3.9, py3.10, py3.11
+    lint, flake8, type, py3.9, py3.10, py3.11, py3.12
 minversion = 4.5.1.1
 isolated_build = true
 
 [gh]
 python =
-    3.11 = py311, type
+    3.12 = py312, type
+    3.11 = py311
     3.10 = py310
     3.9 = py39
-    3.8 = py38
 
 [testenv]
 description = run the tests with pytest


### PR DESCRIPTION
- **Deprecate Python 3.8 and add tests for Python 3.12**
- **Run CI tests only for Python 3.9 and 3.12**
