### PR TITLE
Add version information to `insdb`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # HEAD
 
--   Document `insdb` in the User’s Manual [#21](https://github.com/ziotom78/libinsdb/pull/22)
+-   Add the `--version` command-line switch and the `version` command to `insdb` [#23](https://github.com/ziotom78/libinsdb/pull/23)
+
+-   Document `insdb` in the User’s Manual [#22](https://github.com/ziotom78/libinsdb/pull/22)
 
 -   Add the `open` command to the CLI program `insdb` [#21](https://github.com/ziotom78/libinsdb/pull/21)
 

--- a/libinsdb/__main__.py
+++ b/libinsdb/__main__.py
@@ -553,6 +553,13 @@ def parse_args():
         default=False,
     )
     parser.add_argument(
+        "--version",
+        "-v",
+        help="Print the version and quit",
+        action="version",
+        version=LIBINSDB_VERSION,
+    )
+    parser.add_argument(
         "-c",
         "--command",
         type=str,

--- a/libinsdb/__main__.py
+++ b/libinsdb/__main__.py
@@ -15,7 +15,7 @@ from rich.tree import Tree
 
 from .objects import Entity, Quantity, Release  # noqa: F401
 from .local import LocalInsDb
-
+from .version import LIBINSDB_VERSION
 
 PROMPT_CHARACTER = ">"
 
@@ -54,7 +54,7 @@ def clean_uuid_from_hyphens(text: str) -> str:
 class ImoBrowser(Cmd):
     "Parse an IMo file"
 
-    intro = """Welcome to the InstrumentDB shell.
+    intro = f"""Welcome to Libinsdb shell version {LIBINSDB_VERSION}.
 
 Type 'help' or '?' to list commands, 'quit' to exit.
 """

--- a/libinsdb/__main__.py
+++ b/libinsdb/__main__.py
@@ -525,6 +525,16 @@ Type 'help' or '?' to list commands, 'quit' to exit.
         self._populate_subtree(tree, self.selected_entity_uuid)
 
         self.console.print(tree)
+        return False
+
+    def do_version(self, _):
+        """Print the version number of Libinsdb
+
+        Usage: version
+        """
+
+        self.console.print(f"Libinsdb version {LIBINSDB_VERSION}")
+        return False
 
     def do_quit(self, _):
         """Quit the program


### PR DESCRIPTION
This PR adds three ways to find out the version of the Libinsdb package when using `insdb`:

-   The version number is printed when `insdb` starts
-   It can be printed with `insdb --version` or `insdb -v`
-   There is a new command `version` available in the REPL